### PR TITLE
Add Bluesky comments to blog posts

### DIFF
--- a/src/_includes/layouts/post.html
+++ b/src/_includes/layouts/post.html
@@ -10,10 +10,8 @@ type: article
   <div class="content">{{ content }}</div>
 
   {% if bluesky %}
-  <h3>Discourse</h3>
-  <p class="meta">
-    Comments, questions, corrections? Please drop them on
-    <a href="{{ bluesky }}">Bluesky!</a>
-  </p>
+  <h3>Comments</h3>
+  <div id="bluesky-comments" data-post-url="{{ bluesky }}"></div>
+  <script src="/lib/bluesky-comments.js"></script>
   {% endif %}
 </article>

--- a/src/lib/bluesky-comments.js
+++ b/src/lib/bluesky-comments.js
@@ -1,0 +1,155 @@
+(() => {
+  const container = document.getElementById('bluesky-comments');
+  if (!container) return;
+
+  const postUrl = container.dataset.postUrl;
+  if (!postUrl) return;
+
+  // Convert Bluesky URL to AT URI
+  // https://bsky.app/profile/ates.dev/post/3lbyjgfrxkc2j -> at://ates.dev/app.bsky.feed.post/3lbyjgfrxkc2j
+  const match = postUrl.match(/bsky\.app\/profile\/([^/]+)\/post\/([^/]+)/);
+  if (!match) return;
+
+  const [, handle, rkey] = match;
+  const uri = `at://${handle}/app.bsky.feed.post/${rkey}`;
+
+  function formatDate(dateString) {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-CA', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  function renderComment(comment, depth = 0) {
+    const maxDepth = 3;
+    const isMaxDepth = depth >= maxDepth;
+
+    const div = document.createElement('div');
+    div.className = 'bsky-comment' + (depth > 0 ? ' bsky-reply' : '');
+
+    const authorUrl = `https://bsky.app/profile/${comment.author.handle}`;
+    const postUrl = `https://bsky.app/profile/${comment.author.handle}/post/${comment.uri.split('/').pop()}`;
+
+    div.innerHTML = `
+      <div class="bsky-comment-header">
+        ${comment.author.avatar ? `<img src="${comment.author.avatar}" alt="" class="bsky-avatar">` : ''}
+        <a href="${authorUrl}" target="_blank" rel="noopener" class="bsky-author">
+          ${comment.author.displayName || comment.author.handle}
+        </a>
+        <span class="bsky-handle">@${comment.author.handle}</span>
+        <a href="${postUrl}" target="_blank" rel="noopener" class="bsky-date">${formatDate(comment.createdAt)}</a>
+      </div>
+      <div class="bsky-comment-text">${escapeHtml(comment.text)}</div>
+      <div class="bsky-comment-meta">
+        ${comment.likeCount ? `<span>${comment.likeCount} like${comment.likeCount !== 1 ? 's' : ''}</span>` : ''}
+        ${comment.replyCount ? `<span>${comment.replyCount} repl${comment.replyCount !== 1 ? 'ies' : 'y'}</span>` : ''}
+      </div>
+    `;
+
+    if (comment.replies && comment.replies.length > 0) {
+      if (isMaxDepth) {
+        const moreLink = document.createElement('a');
+        moreLink.href = postUrl;
+        moreLink.target = '_blank';
+        moreLink.rel = 'noopener';
+        moreLink.className = 'bsky-more-replies';
+        moreLink.textContent = `View ${comment.replies.length} more repl${comment.replies.length !== 1 ? 'ies' : 'y'} on Bluesky`;
+        div.appendChild(moreLink);
+      } else {
+        const repliesDiv = document.createElement('div');
+        repliesDiv.className = 'bsky-replies';
+        comment.replies.forEach((reply) => {
+          repliesDiv.appendChild(renderComment(reply, depth + 1));
+        });
+        div.appendChild(repliesDiv);
+      }
+    }
+
+    return div;
+  }
+
+  function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  function parseThread(thread) {
+    if (!thread || thread.$type !== 'app.bsky.feed.defs#threadViewPost') {
+      return null;
+    }
+
+    const post = thread.post;
+    const record = post.record;
+
+    const replies = [];
+    if (thread.replies) {
+      for (const reply of thread.replies) {
+        const parsed = parseThread(reply);
+        if (parsed) replies.push(parsed);
+      }
+      replies.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+    }
+
+    return {
+      uri: post.uri,
+      author: {
+        handle: post.author.handle,
+        displayName: post.author.displayName,
+        avatar: post.author.avatar,
+      },
+      text: record.text,
+      createdAt: record.createdAt,
+      likeCount: post.likeCount || 0,
+      replyCount: post.replyCount || 0,
+      replies,
+    };
+  }
+
+  function render(thread) {
+    container.innerHTML = '';
+
+    if (!thread) {
+      container.innerHTML = '<p class="bsky-error">Could not load comments. <a href="' + postUrl + '" target="_blank" rel="noopener">View on Bluesky</a></p>';
+      return;
+    }
+
+    const stats = document.createElement('div');
+    stats.className = 'bsky-stats';
+    stats.innerHTML = `
+      <span>${thread.likeCount} like${thread.likeCount !== 1 ? 's' : ''}</span>
+      <span>${thread.replyCount} repl${thread.replyCount !== 1 ? 'ies' : 'y'}</span>
+      <a href="${postUrl}" target="_blank" rel="noopener">Reply on Bluesky</a>
+    `;
+    container.appendChild(stats);
+
+    if (thread.replies.length === 0) {
+      const noComments = document.createElement('p');
+      noComments.className = 'bsky-no-comments';
+      noComments.textContent = 'No comments yet.';
+      container.appendChild(noComments);
+      return;
+    }
+
+    const commentsDiv = document.createElement('div');
+    commentsDiv.className = 'bsky-comments-list';
+    thread.replies.forEach((reply) => {
+      commentsDiv.appendChild(renderComment(reply));
+    });
+    container.appendChild(commentsDiv);
+  }
+
+  container.innerHTML = '<p class="bsky-loading">Loading comments...</p>';
+
+  fetch(`https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=${encodeURIComponent(uri)}&depth=6`)
+    .then((res) => res.json())
+    .then((data) => {
+      const thread = parseThread(data.thread);
+      render(thread);
+    })
+    .catch(() => {
+      container.innerHTML = '<p class="bsky-error">Could not load comments. <a href="' + postUrl + '" target="_blank" rel="noopener">View on Bluesky</a></p>';
+    });
+})();

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -460,3 +460,86 @@ th {
     width: 100%;
   }
 }
+
+/* Bluesky Comments */
+
+#bluesky-comments {
+  margin-top: 0.5rlh;
+}
+
+.bsky-loading,
+.bsky-error,
+.bsky-no-comments {
+  color: #888;
+  font-style: italic;
+}
+
+.bsky-stats {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.875rem;
+  color: #888;
+  margin-bottom: 1rlh;
+
+  a {
+    margin-left: auto;
+  }
+}
+
+.bsky-comments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rlh;
+}
+
+.bsky-comment {
+  padding-left: 0;
+}
+
+.bsky-reply {
+  margin-top: 0.5rlh;
+  padding-left: 1rem;
+  border-left: 2px solid #d084ff40;
+}
+
+.bsky-comment-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.bsky-avatar {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  box-shadow: none;
+}
+
+.bsky-author {
+  font-weight: bold;
+}
+
+.bsky-handle,
+.bsky-date {
+  color: #888;
+}
+
+.bsky-comment-text {
+  margin: 0.25rlh 0;
+  white-space: pre-wrap;
+}
+
+.bsky-comment-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.75rem;
+  color: #888;
+}
+
+.bsky-more-replies {
+  display: block;
+  margin-top: 0.5rlh;
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
## Summary
- Adds client-side fetching and display of Bluesky comments on blog posts
- Uses existing `bluesky` frontmatter URLs to fetch comment threads via the public Bluesky API
- Displays nested replies with author info, timestamps, and engagement metrics

Based on https://github.com/danielroe/roe.dev/pull/1793

Closes #30

## Test plan
- [ ] Build site locally and verify comments load on posts with `bluesky` frontmatter
- [ ] Verify loading/error states display correctly
- [ ] Check comment thread nesting and "View more replies" links at max depth
- [ ] Verify styling matches site theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)